### PR TITLE
Fix treesitter crash on Neovim 0.12 and reveal hidden files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # neovim-configuration
 
 A modern Neovim configuration built on [lazy.nvim](https://github.com/folke/lazy.nvim).
-Targets Neovim **0.11+** (developed on 0.12).
+Requires Neovim **0.12+** (nvim-treesitter's `main` branch does not support older versions).
 
 ## Features
 
@@ -18,7 +18,7 @@ Targets Neovim **0.11+** (developed on 0.12).
 
 ## Setup
 
-1. Install [Neovim 0.11+](https://github.com/neovim/neovim/releases).
+1. Install [Neovim 0.12+](https://github.com/neovim/neovim/releases).
 2. Install the external toolchains with the bundled installer (see below), or by hand.
 3. Copy this repo's `nvim/` directory to your Neovim config location:
    - Linux/macOS: `~/.config/nvim`
@@ -34,6 +34,8 @@ The only things you install at the OS level are their runtimes plus a few tools:
 
 - [ripgrep](https://github.com/BurntSushi/ripgrep) - required for Telescope live grep
 - A C compiler + `make` - to build treesitter parsers
+- [tree-sitter CLI](https://github.com/tree-sitter/tree-sitter) - used by nvim-treesitter
+  (`main` branch) to build parsers via `:TSUpdate`/`:TSInstall`
 - `node`/`npm` - for the TypeScript, Vue, ESLint, JSON, and YAML language servers
 - `go` - for gopls and delve (Go debugging)
 - `cargo`/`rustc` - for rust_analyzer

--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,7 @@
 #
 #   ripgrep        Telescope live grep
 #   C compiler     building treesitter parsers
+#   tree-sitter    CLI used by nvim-treesitter (main branch) to build parsers
 #   git, curl      plugin + tool downloads
 #   Node.js        TypeScript / Vue / JSON / YAML / ESLint language servers
 #   Go             gopls + delve (Go debugging)
@@ -114,6 +115,29 @@ else
     rm -rf /tmp/rg.tar.gz "/tmp/ripgrep-${RG_VER}-${RG_ARCH}"
   else
     warn "Could not resolve latest ripgrep release; install it manually (needed for live grep)."
+  fi
+fi
+
+# tree-sitter CLI -> $HOME/.local/bin (no root). Required by nvim-treesitter's
+# `main` branch to build language parsers (it shells out to `tree-sitter build`).
+if have tree-sitter; then
+  info "tree-sitter CLI present: $(tree-sitter --version)"
+elif [ "$PM" = brew ] || [ "$PM" = pacman ]; then
+  info "Installing tree-sitter CLI"; pkg_install tree-sitter
+else
+  info "Installing tree-sitter CLI to \$HOME/.local/bin"
+  TS_ARCH="x64"; [ "$(uname -m)" = "aarch64" ] && TS_ARCH="arm64"
+  TS_VER="$(curl -fsSL https://api.github.com/repos/tree-sitter/tree-sitter/releases/latest \
+    | grep -Po '"tag_name":\s*"\K[^"]*' || true)"
+  if [ -n "$TS_VER" ]; then
+    curl -fsSLo /tmp/tree-sitter.gz \
+      "https://github.com/tree-sitter/tree-sitter/releases/download/${TS_VER}/tree-sitter-linux-${TS_ARCH}.gz"
+    gunzip -f /tmp/tree-sitter.gz
+    install /tmp/tree-sitter "$LOCAL_BIN/tree-sitter"
+    rm -f /tmp/tree-sitter
+  else
+    warn "Could not resolve latest tree-sitter release; install the CLI manually"
+    warn "(needed to build treesitter parsers): https://github.com/tree-sitter/tree-sitter/releases"
   fi
 fi
 

--- a/nvim/lazy-lock.json
+++ b/nvim/lazy-lock.json
@@ -16,12 +16,13 @@
   "nvim-dap-virtual-text": { "branch": "master", "commit": "fbdb48c2ed45f4a8293d0d483f7730d24467ccb6" },
   "nvim-lspconfig": { "branch": "master", "commit": "d224a1920728ba129880efc700d4a0180ac4ecbb" },
   "nvim-nio": { "branch": "master", "commit": "21f5324bfac14e22ba26553caf69ec76ae8a7662" },
-  "nvim-tree.lua": { "branch": "master", "commit": "35d3511e7ad4cbfa44c78c406db663b6e2a07c0d" },
-  "nvim-treesitter": { "branch": "master", "commit": "cf12346a3414fa1b06af75c79faebe7f76df080a" },
+  "nvim-tree.lua": { "branch": "master", "commit": "a797d5e20133fc031fba4aa7d1272f5b1d950a1c" },
+  "nvim-treesitter": { "branch": "main", "commit": "4916d6592ede8c07973490d9322f187e07dfefac" },
   "nvim-web-devicons": { "branch": "master", "commit": "dad71387de386a946b123079d0e53f23028f3abd" },
   "plenary.nvim": { "branch": "master", "commit": "74b06c6c75e4eeb3108ec01852001636d85a932b" },
   "telescope-file-browser.nvim": { "branch": "master", "commit": "3610dc7dc91f06aa98b11dca5cc30dfa98626b7e" },
   "telescope.nvim": { "branch": "master", "commit": "427b576c16792edad01a92b89721d923c19ad60f" },
   "toggleterm.nvim": { "branch": "main", "commit": "50ea089fc548917cc3cc16b46a8211833b9e3c7c" },
-  "trouble.nvim": { "branch": "main", "commit": "bd67efe408d4816e25e8491cc5ad4088e708a69a" }
+  "trouble.nvim": { "branch": "main", "commit": "bd67efe408d4816e25e8491cc5ad4088e708a69a" },
+  "which-key.nvim": { "branch": "main", "commit": "3aab2147e74890957785941f0c1ad87d0a44c15a" }
 }

--- a/nvim/lua/bitlytwiser/plugins/editor.lua
+++ b/nvim/lua/bitlytwiser/plugins/editor.lua
@@ -45,6 +45,13 @@ return {
           },
         },
         diagnostics = { enable = true, show_on_dirs = true },
+        -- Show hidden files by default. Dotfiles already show (dotfiles = false), but
+        -- git-ignored entries are hidden by default (git_ignored = true) - set both
+        -- false so nothing is hidden. Toggle at runtime with `H` (dotfiles) / `I` (ignored).
+        filters = {
+          dotfiles = false,
+          git_ignored = false,
+        },
       })
     end,
   },

--- a/nvim/lua/bitlytwiser/plugins/telescope.lua
+++ b/nvim/lua/bitlytwiser/plugins/telescope.lua
@@ -8,7 +8,9 @@ return {
   },
   keys = {
     -- <leader>fg is live_grep, which shells out to ripgrep.
-    { "<leader>ff", function() require("telescope.builtin").find_files({ hidden = true }) end, desc = "Find files" },
+    -- hidden = show dotfiles; no_ignore = also show git-ignored files (e.g. .env,
+    -- .env.development). node_modules/.git are still filtered via defaults.file_ignore_patterns.
+    { "<leader>ff", function() require("telescope.builtin").find_files({ hidden = true, no_ignore = true }) end, desc = "Find files" },
     { "<leader>fg", function() require("telescope.builtin").live_grep({ hidden = true }) end, desc = "Live grep (ripgrep)" },
     { "<leader>fbuff", function() require("telescope.builtin").buffers() end, desc = "Find buffers" },
     { "<leader>fh", function() require("telescope.builtin").help_tags() end, desc = "Help tags" },

--- a/nvim/lua/bitlytwiser/plugins/treesitter.lua
+++ b/nvim/lua/bitlytwiser/plugins/treesitter.lua
@@ -1,47 +1,59 @@
 return {
   "nvim-treesitter/nvim-treesitter",
-  -- Pin the classic `master` API (configs.setup with highlight/indent modules).
-  -- The default `main` branch is a rewrite with an incompatible API.
-  branch = "master",
+  -- The `master` branch is frozen and does NOT support Neovim 0.12 (it crashes the
+  -- highlighter with "attempt to call method 'range' (a nil value)"). Use the maintained
+  -- `main` branch, which targets Neovim 0.12+ but has a different, module-less API:
+  -- parsers are installed via require("nvim-treesitter").install(), and highlighting /
+  -- indentation are enabled per-buffer through Neovim core APIs in a FileType autocmd.
+  branch = "main",
+  lazy = false, -- eager load so the FileType autocmd is armed before the first buffer
   build = ":TSUpdate",
-  event = { "BufReadPost", "BufNewFile" },
-  cmd = { "TSUpdate", "TSInstall", "TSInstallInfo" },
   config = function()
-    require("nvim-treesitter.configs").setup({
-      -- Curated list instead of "all" (which is heavy and needs the tree-sitter CLI).
-      ensure_installed = {
-        "lua",
-        "vim",
-        "vimdoc",
-        "go",
-        "gomod",
-        "gosum",
-        "rust",
-        "typescript",
-        "javascript",
-        "tsx",
-        "vue",
-        "python",
-        "json",
-        "jsonc",
-        "yaml",
-        "html",
-        "css",
-        "bash",
-        "markdown",
-        "markdown_inline",
-        "toml",
-      },
-      auto_install = false,
-      sync_install = false,
-      highlight = {
-        enable = true,
-        additional_vim_regex_highlighting = false,
-      },
-      indent = {
-        enable = true,
-        disable = { "yaml" },
-      },
+    local parsers = {
+      "lua",
+      "vim",
+      "vimdoc",
+      "go",
+      "gomod",
+      "gosum",
+      "rust",
+      "typescript",
+      "javascript",
+      "tsx",
+      "vue",
+      "python",
+      "json",
+      "yaml",
+      "html",
+      "css",
+      "bash",
+      "markdown",
+      "markdown_inline",
+      "toml",
+    }
+
+    -- Install/update any missing parsers (async; a no-op for already-installed ones).
+    require("nvim-treesitter").install(parsers)
+
+    -- The `main` branch has no separate `jsonc` parser; reuse the `json` parser for
+    -- jsonc buffers (tsconfig.json, .jsonc, ...) so they still get treesitter highlighting.
+    vim.treesitter.language.register("json", "jsonc")
+
+    -- Enable treesitter highlighting + indentation for any buffer whose filetype has an
+    -- installed parser. pcall no-ops on filetypes without a parser, so no explicit
+    -- filetype list is needed (parser names like markdown_inline/gomod are not filetypes).
+    vim.api.nvim_create_autocmd("FileType", {
+      callback = function(args)
+        local buf = args.buf
+        if not pcall(vim.treesitter.start, buf) then
+          return -- no parser for this filetype; leave default syntax highlighting
+        end
+        -- Treesitter indentation (experimental upstream). Match the old config, which
+        -- disabled treesitter indent for yaml.
+        if vim.bo[buf].filetype ~= "yaml" then
+          vim.bo[buf].indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
+        end
+      end,
     })
   end,
 }


### PR DESCRIPTION
Migrate nvim-treesitter from the frozen master branch (which does not support Neovim 0.12 and crashed the highlighter on Telescope previews) to the maintained main branch, using its new install/highlight/indent API. Rebuild parsers via the tree-sitter CLI.

Also surface hidden files: nvim-tree now shows dotfiles and git-ignored entries, and Telescope find_files (leader ff) shows git-ignored files like .env via no_ignore, while still filtering node_modules and .git.

Add the tree-sitter CLI to install.sh (new dependency for the main branch) and update the README to require Neovim 0.12+.